### PR TITLE
Request: Add WordPress plugin to description

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ _Orange Confort+_ aims to enhance user experience on websites. It works best whe
   
 You could use the plugin [Orange Confort+ for WordPress](https://wordpress.org/plugins/orange-confort-plus/) is available. Thanks to [@RavanH](https://github.com/RavanH).
 
-_N.B: This plugin is not directly maintained by the core team of this project, in case of issues please use the support from wordpress_ 
+_N.B: This plugin is not directly maintained by the core team of this project, in case of issues please use the [plugin support from wordpress](https://wordpress.org/support/plugin/orange-confort-plus/)_ 
 
 **Onto your own domain**
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,15 @@ _Orange Confort+_ aims to enhance user experience on websites. It works best whe
 
 ## Deploying _Orange Confort+_ on your website
 
-To deploy _Orange Confort+_ on a WordPress site, the plugin [Orange Confort+ for WordPress](https://wordpress.org/plugins/orange-confort-plus/) is available.
+**WordPress site**
+  
+You could use the plugin [Orange Confort+ for WordPress](https://wordpress.org/plugins/orange-confort-plus/) is available. Thanks to [@RavanH](https://github.com/RavanH).
 
-To deploy _Orange Confort+_ onto your domain, a prepackaged version is available: simply add the `dist/serveur` folder to your website.
+_N.B: This plugin is not directly maintained by the core team of this project, in case of issues please use the support from wordpress_ 
+
+**Onto your own domain**
+
+A prepackaged version is available: simply add the `dist/serveur` folder to your website.
 
 ### Customize path
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ _Orange Confort+_ aims to enhance user experience on websites. It works best whe
 
 ## Deploying _Orange Confort+_ on your website
 
+To deploy _Orange Confort+_ on a WordPress site, the plugin [Orange Confort+ for WordPress](https://wordpress.org/plugins/orange-confort-plus/) is available.
+
 To deploy _Orange Confort+_ onto your domain, a prepackaged version is available: simply add the `dist/serveur` folder to your website.
 
 ### Customize path

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ _Orange Confort+_ aims to enhance user experience on websites. It works best whe
 
 **WordPress site**
   
-You could use the plugin [Orange Confort+ for WordPress](https://wordpress.org/plugins/orange-confort-plus/) is available. Thanks to [@RavanH](https://github.com/RavanH).
+A tailor-made [Orange Confort+ for WordPress](https://wordpress.org/plugins/orange-confort-plus/) plugin is available. Thanks to [@RavanH](https://github.com/RavanH).
 
-_N.B: This plugin is not directly maintained by the core team of this project, in case of issues please use the [plugin support from wordpress](https://wordpress.org/support/plugin/orange-confort-plus/)_ 
+_N.B: This plugin is not directly maintained by the Confort+ core team, in case of issues please use the [plugin support from wordpress](https://wordpress.org/support/plugin/orange-confort-plus/)_ 
 
-**Onto your own domain**
+**On your own domain**
 
 A prepackaged version is available: simply add the `dist/serveur` folder to your website.
 


### PR DESCRIPTION
For easy deployment on WordPress websites, the plugin https://wordpress.org/plugins/orange-confort-plus/ is available. It might be practical to add this fact to the Readme.

I've added a line with link to the WordPress.org plugin page as a suggestion :)
